### PR TITLE
Fix dataset url in crash course notebook, update link_check workflow to work with latest ubuntu

### DIFF
--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libopenblas-dev ninja-build ccache python3-sphinx \
-              pandoc gcc-7 g++-7 libopencv-dev protobuf-compiler libprotobuf-dev
+              pandoc gcc g++ libopencv-dev protobuf-compiler libprotobuf-dev
           ccache -M 500M  # Limit the ccache size; Github's overall cache limit is 5GB
           python -m pip install pandoc-attributes==0.1.7
           python -m pip install -r docs/python_docs/requirements
@@ -46,8 +46,8 @@ jobs:
 
       - name: Build project
         env:
-          CC: gcc-7
-          CXX: g++-7
+          CC: gcc
+          CXX: g++
         run: |
           git submodule update --init --recursive
           mkdir build; cd build

--- a/docs/python_docs/python/tutorials/getting-started/crash-course/6-train-nn.md
+++ b/docs/python_docs/python/tutorials/getting-started/crash-course/6-train-nn.md
@@ -50,7 +50,7 @@ mx.np.random.seed(42)
 
 ```{.python .input}
 # Download dataset
-url = 'https://md-datasets-cache-zipfiles-prod.s3.eu-west-1.amazonaws.com/hb74ynkjcn-1.zip'
+url = 'https://prod-dcd-datasets-cache-zipfiles.s3.eu-west-1.amazonaws.com/hb74ynkjcn-1.zip'
 zip_file_path = mx.gluon.utils.download(url)
 
 os.makedirs('plants', exist_ok=True)


### PR DESCRIPTION
## Description ##
The CI tests are currently failing due to a broken URL for datasets. This PR updates the URL to the new location.

This PR also changes the dependencies (gcc and g++) for the link_check github workflow to use the standard versions, which allows this workflow to properly run using the `ubuntu-latest` environment.